### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,7 +79,7 @@ and uploaded it to PyPI.
 .. |Build Status| image:: https://travis-ci.org/tonyseek/sphinx-kr-theme.svg?branch=master,develop
    :target: https://travis-ci.org/tonyseek/sphinx-kr-theme
    :alt: Build Status
-.. |Wheel Status| image:: https://pypip.in/wheel/sphinx-kr-theme/badge.svg?style=flat
+.. |Wheel Status| image:: https://img.shields.io/pypi/wheel/sphinx-kr-theme.svg?style=flat
    :target: https://pypi.python.org/pypi/sphinx-kr-theme
    :alt: Wheel Status
 .. |PyPI Version| image:: https://img.shields.io/pypi/v/sphinx-kr-theme.svg?style=flat


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20sphinx-kr-theme))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `sphinx-kr-theme`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.